### PR TITLE
coregrind: m_syswrap: fix the build on FreeBSD 11.3

### DIFF
--- a/coregrind/m_syswrap/priv_syswrap-freebsd.h
+++ b/coregrind/m_syswrap/priv_syswrap-freebsd.h
@@ -514,9 +514,9 @@ DECL_TEMPLATE(freebsd, sys_fhlink) // 565
 DECL_TEMPLATE(freebsd, sys_fhlinkat) // 566
 DECL_TEMPLATE(freebsd, sys_fhreadlink) // 567
 
-DECL_TEMPLATE(freebsd, sys_fake_sigreturn)
-
 #endif
+
+DECL_TEMPLATE(freebsd, sys_fake_sigreturn)
 
 #endif   // PRIV_SYSWRAP_FREEBSD_H
 


### PR DESCRIPTION
The only error that crops up on FreeBSD 11.3 is that the syswrap bits
for sys_fake_sigreturn are only declared for >= FreeBSD12. Discussion with
paulfloyd out-of-band shows this to be essential for all versions, so
move the declaration out.