### PR TITLE
coregrind: m_syswrap: catch up on 13.0-CURRENT fcntls

### DIFF
--- a/coregrind/m_syswrap/syswrap-freebsd.c
+++ b/coregrind/m_syswrap/syswrap-freebsd.c
@@ -1247,6 +1247,8 @@ PRE(sys_fcntl)
    case VKI_F_GETFD:
    case VKI_F_GETFL:
    case VKI_F_GETOWN:
+   case VKI_F_GET_SEALS:
+   case VKI_F_ISUNIONSTACK:
       PRINT("sys_fcntl ( %" FMT_REGWORD "d, %" FMT_REGWORD "d )", SARG1,SARG2);
       PRE_REG_READ2(int, "fcntl", int, fd, int, cmd);
       break;
@@ -1259,6 +1261,7 @@ PRE(sys_fcntl)
    case VKI_F_SETOWN:
    case VKI_F_READAHEAD:
    case VKI_F_RDAHEAD:
+   case VKI_F_ADD_SEALS:
       PRINT("sys_fcntl[ARG3=='arg'] ( %" FMT_REGWORD "d, %" FMT_REGWORD "d, %" FMT_REGWORD "d )", SARG1,SARG2,SARG3);
       PRE_REG_READ3(int, "fcntl",
                     int, fd, int, cmd, int, arg);

--- a/include/vki/vki-freebsd.h
+++ b/include/vki/vki-freebsd.h
@@ -1534,9 +1534,18 @@ struct vki_dirent {
 #define VKI_F_RDAHEAD		16	/* Darwin compatible read ahead */
 #define VKI_F_DUPFD_CLOEXEC	17	/* dup close_on_exec */
 #define VKI_F_DUP2FD_CLOEXEC	18	/* Like F_DUP2FD, but FD_CLOEXEC is set */
+#define VKI_F_ADD_SEALS		19	/* apply seals to underlying file */
+#define VKI_F_GET_SEALS		20	/* get seals to underlying file */
+#define VKI_F_ISUNIONSTACK	21	/* kludge for libc (part of a union stack?) */
 
 /* for F_[GET|SET]FL */
 #define VKI_FD_CLOEXEC	1	/* actually anything with low bit set goes */
+
+/* for F_[ADD|GET]_SEALS */
+#define VKI_F_SEAL_SEAL		0x0001
+#define VKI_F_SEAL_SHRINK	0x0002
+#define VKI_F_SEAL_GROW		0x0004
+#define VKI_F_SEAL_WRITE	0x0008
 
 //----------------------------------------------------------------------
 // From sys/unistd.h


### PR DESCRIPTION
13.0-CURRENT has thus far added the following new fcntls:
- F_ADD_SEALS
- F_GET_SEALS
- F_ISUNIONSTACK

Handle these appropriately.